### PR TITLE
Combine Soldier Types Implemented

### DIFF
--- a/scripts/vscripts/XenThugGamemode.lua
+++ b/scripts/vscripts/XenThugGamemode.lua
@@ -75,7 +75,19 @@ function _G.SpawnWave(waveNr)
 			UpdateClassesAmounts[c] = WaveList[waveNr][i]
 
 			for j = 1, WaveList[waveNr][i], 1 do
-				CommandStack.Add("ent_create "..EntEnums[i])
+				combineType = ""
+
+				if EntEnums[i] == "npc_combine_s" then
+					if j < (WaveList[waveNr][i] * 0.2) then
+						combineType = " {model models/characters/combine_soldier_heavy/combine_soldier_heavy.vmdl}"
+					elseif j < (WaveList[waveNr][i] * 0.4) then
+						combineType = " {model models/characters/combine_suppressor/combine_suppressor.vmdl}"
+					elseif j < (WaveList[waveNr][i] * 0.6) then
+						combineType = " {model models/characters/combine_soldier_captain/combine_captain.vmdl}"
+					end
+				end
+
+				CommandStack.Add("ent_create "..EntEnums[i]..combineType)
 				
 				d = d + 1
 				if d > #SpawnLocation then
@@ -83,7 +95,7 @@ function _G.SpawnWave(waveNr)
 				end
 				
 				if DebugEnabled == true then
-					ModDebug("Spawning Enemy: " .. EntEnums[i])
+					ModDebug("Spawning Enemy: " .. EntEnums[i]..combineType)
 				end
 			end
 			


### PR DESCRIPTION
Combine soldier types (other than default Grunt type) has been added to the mod. No structure change is made, just simple system with percentages is implemented so other combine type can be spawned in game. Percentages are;

Grunt (Default): %40 (https://combineoverwiki.net/wiki/Combine_Grunt)
Ordinal (Captain): %20 (https://combineoverwiki.net/wiki/Combine_Ordinal)
Suppressor: %20 (https://combineoverwiki.net/wiki/Combine_Suppressor)
Charger (Heavy): %20 (https://combineoverwiki.net/wiki/Combine_Charger)

For example if a wave has 6 combine soldiers to spawn, we'll get 3 Grunts and 1 soldier for each type. This brings new random game-play mechanics to mod because for example Ordinals can deploy Manhacks by themselves, Chargers can generate a shield when they get hurt, you can get pistol and SMG ammo from new combines etc.

Personnel note: I really loved the mod and finished it several times. But I always thought why there is no other types of combines, so I decided to get my hands dirty without any structure change. If you were planning to implement them with another way, just ignore this. If you didn't plan anything about it, you can check my code, it's so basic but it works. I also tried to add them as separate enemy types to enemy matrix (to places which were '???') so we can set enemy type counts separately but I had some trouble with spawn points. I can also generate some new waves after wave 18, I only do it for myself for now.